### PR TITLE
feat: add authentication to API routes and WebSocket endpoints

### DIFF
--- a/docs/2026-03-05-auth-middleware.md
+++ b/docs/2026-03-05-auth-middleware.md
@@ -1,0 +1,146 @@
+# Implementation Plan: Add Authentication to API Routes and WebSocket Endpoints
+
+**Issue:** #1 — Add authentication to API routes and WebSocket endpoints
+**Date:** 2026-03-05
+
+## Problem
+
+All Next.js API routes, WebSocket servers, and terminal servers have zero authentication. Any client on the network can perform privileged actions: spawning agents, sending commands, killing sessions, merging PRs, and getting full terminal access.
+
+## Design
+
+### Shared Secret Approach
+
+Generate a random shared secret at startup. Store it in the data directory so all components (Next.js, terminal servers) can read it. Require it via `Authorization: Bearer <token>` header for HTTP routes and via query parameter for WebSocket connections.
+
+### Secret Generation & Storage
+
+1. On first startup (`ao start` or when the web server initializes), generate a 256-bit random token using `node:crypto.randomBytes(32).toString('hex')`.
+2. Write it to `<dataDir>/.ao-auth-token` with mode `0600`.
+3. If the file already exists, read and reuse it (idempotent restarts).
+4. The token persists across restarts but is regenerated on `ao init` or explicit reset.
+
+### Implementation Tasks
+
+#### Task 1: Create auth utility module (`packages/web/src/lib/auth.ts`)
+
+Create a new module that:
+- Reads the auth token from `<dataDir>/.ao-auth-token`
+- Falls back to `AO_AUTH_TOKEN` environment variable
+- Provides `getAuthToken(): string | null` to load the token
+- Provides `validateRequest(request: NextRequest): NextResponse | null` that:
+  - Returns `null` if auth is valid (caller proceeds normally)
+  - Returns a 401 `NextResponse` if auth fails
+- If no token file and no env var exist, auth is disabled (open-source default for local dev)
+- Caches the token in memory after first read
+
+#### Task 2: Create auth token generation in core (`packages/core/src/auth.ts`)
+
+Create a utility function:
+- `ensureAuthToken(dataDir: string): string` — reads existing token or generates and writes a new one
+- `getAuthTokenPath(dataDir: string): string` — returns the token file path
+- Uses `node:crypto.randomBytes(32).toString('hex')` for generation
+- Writes with `0600` permissions
+- Exports from `packages/core/src/index.ts`
+
+#### Task 3: Add auth to Next.js API routes via middleware (`packages/web/src/middleware.ts`)
+
+Create Next.js middleware (the standard `middleware.ts` pattern):
+- Matches all `/api/*` routes
+- Reads the auth token from env or file
+- Checks `Authorization: Bearer <token>` header
+- Returns 401 for missing/invalid token
+- Passes through if no token configured (dev mode)
+- Does NOT protect static assets or page routes (dashboard is read-only after auth)
+
+#### Task 4: Add auth to Direct Terminal WebSocket server (`packages/web/server/direct-terminal-ws.ts`)
+
+- Add `verifyClient` callback to `WebSocketServer` constructor
+- Check for `token` query parameter: `ws://host/ws?session=X&token=Y`
+- Read auth token from same source as middleware
+- Reject connection with 401 if token is invalid
+- Pass through if no token configured
+- Also protect the `/health` endpoint (leaks session IDs)
+
+#### Task 5: Add auth to Terminal WebSocket server (`packages/web/server/terminal-websocket.ts`)
+
+- Check for `Authorization` header or `token` query parameter on HTTP requests
+- Reject with 401 if token is invalid
+- Pass through if no token configured
+- Also protect the `/health` endpoint
+
+#### Task 6: Update frontend to send auth token
+
+- Read token from `NEXT_PUBLIC_AO_AUTH_TOKEN` env var or a server-side API
+- Add `Authorization` header to all `fetch()` calls in Dashboard components
+- Add `token` query parameter to WebSocket connections in `DirectTerminal.tsx`
+- Add token to SSE `EventSource` via custom fetch (EventSource doesn't support headers natively, use polyfill or switch to fetch-based SSE)
+
+Actually, for the frontend: since the dashboard and API are on the same origin, we can use a simpler approach:
+- Create a `/api/auth/token` endpoint that serves the token to the page (protected by... itself being an API route, so this is circular)
+- Better approach: **inject the token into the page via a server component** or use a **cookie-based session** after initial auth
+
+Simplest viable approach for v1:
+- The dashboard serves from the same process as the API
+- Set the token as an `httpOnly` cookie on the initial page load
+- All `fetch()` and EventSource calls automatically include cookies
+- WebSocket connections add the token as a query parameter (read from a non-httpOnly cookie or a `<meta>` tag)
+
+Even simpler: **use a single long-lived cookie set by Next.js middleware**:
+1. On first page visit, middleware checks if `ao-auth` cookie exists
+2. If not, check `Authorization` header or `token` query param
+3. If valid, set `ao-auth` cookie and proceed
+4. Subsequent requests (fetch, SSE) include the cookie automatically
+5. WebSocket connections read the cookie value and pass as query param
+
+**Revised simplest approach**:
+- API routes check `Authorization: Bearer <token>` header
+- Dashboard pages are unprotected (they're just static HTML/JS)
+- The dashboard reads the token from `NEXT_PUBLIC_AO_AUTH_TOKEN` environment variable
+- Dashboard JS adds `Authorization` header to all API calls
+- WebSocket connections use `token` query parameter
+- For EventSource (no custom headers), switch to fetch-based SSE or pass token as query parameter
+
+This is the most straightforward approach. The token is visible in the browser env, but that's acceptable because:
+1. This is a local dev tool, not a production SaaS
+2. The token prevents casual LAN attacks, not browser-based attacks
+3. If someone has access to the browser, they already have access to everything
+
+#### Task 7: Update `ao start` to generate and display the auth token
+
+- Call `ensureAuthToken(dataDir)` during startup
+- Set `AO_AUTH_TOKEN` env var for the web process
+- Set `NEXT_PUBLIC_AO_AUTH_TOKEN` env var so Next.js exposes it to the client
+- Print the token to the console: "Dashboard auth token: <token>"
+
+#### Task 8: Write tests
+
+- Unit tests for `auth.ts` (token generation, validation)
+- Unit tests for middleware (401 on missing/bad token, pass-through with valid token, pass-through when no token configured)
+- Integration tests for WebSocket auth rejection
+- Update existing API route tests to include auth header
+
+## Files Changed
+
+### New Files
+- `packages/core/src/auth.ts` — token generation/management
+- `packages/web/src/lib/auth.ts` — token validation helpers for web
+- `packages/web/src/middleware.ts` — Next.js auth middleware
+
+### Modified Files
+- `packages/core/src/index.ts` — re-export auth functions
+- `packages/web/server/direct-terminal-ws.ts` — add `verifyClient` + health auth
+- `packages/web/server/terminal-websocket.ts` — add auth check to HTTP handler
+- `packages/web/src/components/DirectTerminal.tsx` — add token to WebSocket URL
+- `packages/web/src/hooks/useSessionEvents.ts` — add token to EventSource (if feasible)
+- `packages/web/src/components/Dashboard.tsx` — add auth headers to fetch calls
+- `packages/web/src/__tests__/api-routes.test.ts` — update tests for auth
+- `packages/core/src/types.ts` — no changes needed (token is infra, not plugin interface)
+
+## Non-Goals
+
+- Full user management / multi-user auth (out of scope)
+- OAuth / SSO (out of scope)
+- RBAC / permissions (out of scope)
+- Rate limiting (separate issue)
+- HTTPS enforcement (separate concern, usually handled by reverse proxy)

--- a/packages/cli/src/commands/dashboard.ts
+++ b/packages/cli/src/commands/dashboard.ts
@@ -3,7 +3,7 @@ import { resolve } from "node:path";
 import { existsSync } from "node:fs";
 import chalk from "chalk";
 import type { Command } from "commander";
-import { loadConfig } from "@composio/ao-core";
+import { loadConfig, ensureAuthToken } from "@composio/ao-core";
 import { findWebDir, buildDashboardEnv, waitForPortAndOpen } from "../lib/web-dir.js";
 import { cleanNextCache, findRunningDashboardPid, findProcessWebDir, waitForPortFree } from "../lib/dashboard-rebuild.js";
 
@@ -65,12 +65,14 @@ export function registerDashboard(program: Command): void {
 
       console.log(chalk.bold(`Starting dashboard on http://${host}:${port}\n`));
 
+      const authToken = ensureAuthToken();
       const env = await buildDashboardEnv(
         port,
         config.configPath,
         config.terminalPort,
         config.directTerminalPort,
         host,
+        authToken,
       );
 
       const child = spawn("npx", ["next", "dev", "-p", String(port), "-H", host], {

--- a/packages/cli/src/commands/start.ts
+++ b/packages/cli/src/commands/start.ts
@@ -24,6 +24,7 @@ import {
   isRepoAlreadyCloned,
   generateConfigFromUrl,
   configToYaml,
+  ensureAuthToken,
   type OrchestratorConfig,
   type ProjectConfig,
   type ParsedRepoUrl,
@@ -220,8 +221,9 @@ async function startDashboard(
   terminalPort?: number,
   directTerminalPort?: number,
   host?: string,
+  authToken?: string,
 ): Promise<ChildProcess> {
-  const env = await buildDashboardEnv(port, configPath, terminalPort, directTerminalPort, host);
+  const env = await buildDashboardEnv(port, configPath, terminalPort, directTerminalPort, host, authToken);
 
   const child = spawn("pnpm", ["run", "dev"], {
     cwd: webDir,
@@ -252,6 +254,9 @@ async function runStartup(
   const sessionId = `${project.sessionPrefix}-orchestrator`;
   let port = config.port ?? DEFAULT_PORT;
   const host = config.host ?? "127.0.0.1";
+
+  // Generate or read auth token
+  const authToken = ensureAuthToken();
 
   console.log(chalk.bold(`\nStarting orchestrator for ${chalk.cyan(project.name)}\n`));
 
@@ -294,6 +299,7 @@ async function runStartup(
       config.terminalPort,
       config.directTerminalPort,
       host,
+      authToken,
     );
     spinner.succeed(`Dashboard starting on http://${host}:${port}`);
     console.log(chalk.dim("  (Dashboard will be ready in a few seconds)\n"));
@@ -350,6 +356,7 @@ async function runStartup(
     console.log(chalk.cyan("Orchestrator:"), `already running (${sessionId})`);
   }
 
+  console.log(chalk.cyan("Auth token:"), authToken);
   console.log(chalk.dim(`Config: ${config.configPath}\n`));
 
   // Auto-open browser to orchestrator session page once the server is accepting connections.

--- a/packages/cli/src/lib/web-dir.ts
+++ b/packages/cli/src/lib/web-dir.ts
@@ -114,6 +114,7 @@ export async function buildDashboardEnv(
   terminalPort?: number,
   directTerminalPort?: number,
   host?: string,
+  authToken?: string,
 ): Promise<Record<string, string>> {
   const env: Record<string, string> = { ...process.env } as Record<string, string>;
 
@@ -158,6 +159,12 @@ export async function buildDashboardEnv(
   env["DIRECT_TERMINAL_PORT"] = String(resolvedDirect);
   env["NEXT_PUBLIC_TERMINAL_PORT"] = String(resolvedTerminal);
   env["NEXT_PUBLIC_DIRECT_TERMINAL_PORT"] = String(resolvedDirect);
+
+  // Pass auth token to both server-side and client-side
+  if (authToken) {
+    env["AO_AUTH_TOKEN"] = authToken;
+    env["NEXT_PUBLIC_AO_AUTH_TOKEN"] = authToken;
+  }
 
   return env;
 }

--- a/packages/core/src/__tests__/auth.test.ts
+++ b/packages/core/src/__tests__/auth.test.ts
@@ -1,0 +1,115 @@
+import { describe, it, expect, beforeEach, afterEach } from "vitest";
+import { readFileSync, existsSync, mkdirSync, rmSync, writeFileSync } from "node:fs";
+import { join } from "node:path";
+import { tmpdir } from "node:os";
+import { ensureAuthToken, readAuthToken, getAuthTokenPath } from "../auth.js";
+
+const TEST_DIR = join(tmpdir(), `ao-auth-test-${process.pid}`);
+
+beforeEach(() => {
+  // Clean test directory
+  if (existsSync(TEST_DIR)) {
+    rmSync(TEST_DIR, { recursive: true });
+  }
+  mkdirSync(TEST_DIR, { recursive: true });
+  // Clear env var
+  delete process.env["AO_AUTH_TOKEN"];
+});
+
+afterEach(() => {
+  if (existsSync(TEST_DIR)) {
+    rmSync(TEST_DIR, { recursive: true });
+  }
+  delete process.env["AO_AUTH_TOKEN"];
+});
+
+describe("getAuthTokenPath", () => {
+  it("returns path under given data dir", () => {
+    const path = getAuthTokenPath("/tmp/test");
+    expect(path).toBe("/tmp/test/.ao-auth-token");
+  });
+});
+
+describe("readAuthToken", () => {
+  it("returns null when no token configured", () => {
+    const token = readAuthToken(TEST_DIR);
+    expect(token).toBeNull();
+  });
+
+  it("returns env var token when set", () => {
+    process.env["AO_AUTH_TOKEN"] = "test-token-from-env";
+    const token = readAuthToken(TEST_DIR);
+    expect(token).toBe("test-token-from-env");
+  });
+
+  it("returns file token when file exists", () => {
+    writeFileSync(join(TEST_DIR, ".ao-auth-token"), "test-token-from-file\n");
+    const token = readAuthToken(TEST_DIR);
+    expect(token).toBe("test-token-from-file");
+  });
+
+  it("prefers env var over file", () => {
+    process.env["AO_AUTH_TOKEN"] = "env-token";
+    writeFileSync(join(TEST_DIR, ".ao-auth-token"), "file-token\n");
+    const token = readAuthToken(TEST_DIR);
+    expect(token).toBe("env-token");
+  });
+
+  it("returns null for empty file", () => {
+    writeFileSync(join(TEST_DIR, ".ao-auth-token"), "");
+    const token = readAuthToken(TEST_DIR);
+    expect(token).toBeNull();
+  });
+
+  it("trims whitespace from env var", () => {
+    process.env["AO_AUTH_TOKEN"] = "  spaced-token  ";
+    const token = readAuthToken(TEST_DIR);
+    expect(token).toBe("spaced-token");
+  });
+});
+
+describe("ensureAuthToken", () => {
+  it("generates a new token when none exists", () => {
+    const token = ensureAuthToken(TEST_DIR);
+    expect(token).toMatch(/^[0-9a-f]{64}$/);
+
+    // Token file should be created
+    const filePath = join(TEST_DIR, ".ao-auth-token");
+    expect(existsSync(filePath)).toBe(true);
+
+    // File content should match
+    const fileContent = readFileSync(filePath, "utf-8").trim();
+    expect(fileContent).toBe(token);
+  });
+
+  it("reuses existing token", () => {
+    writeFileSync(join(TEST_DIR, ".ao-auth-token"), "existing-token\n");
+    const token = ensureAuthToken(TEST_DIR);
+    expect(token).toBe("existing-token");
+  });
+
+  it("returns env var token without writing file", () => {
+    process.env["AO_AUTH_TOKEN"] = "env-override";
+    const token = ensureAuthToken(TEST_DIR);
+    expect(token).toBe("env-override");
+
+    // Should not create file
+    const filePath = join(TEST_DIR, ".ao-auth-token");
+    expect(existsSync(filePath)).toBe(false);
+  });
+
+  it("creates data directory if missing", () => {
+    const nestedDir = join(TEST_DIR, "nested", "deep");
+    const token = ensureAuthToken(nestedDir);
+    expect(token).toMatch(/^[0-9a-f]{64}$/);
+    expect(existsSync(nestedDir)).toBe(true);
+  });
+
+  it("generates different tokens on separate calls to fresh dirs", () => {
+    const dir1 = join(TEST_DIR, "dir1");
+    const dir2 = join(TEST_DIR, "dir2");
+    const token1 = ensureAuthToken(dir1);
+    const token2 = ensureAuthToken(dir2);
+    expect(token1).not.toBe(token2);
+  });
+});

--- a/packages/core/src/auth.ts
+++ b/packages/core/src/auth.ts
@@ -1,0 +1,105 @@
+/**
+ * Authentication token management.
+ *
+ * Generates and persists a shared secret used by the web dashboard and
+ * terminal servers to authenticate requests. The token is a 256-bit
+ * random hex string stored at ~/.agent-orchestrator/.ao-auth-token
+ * with mode 0600.
+ *
+ * Token lifecycle:
+ *   - Generated once on first `ao start`, persisted across restarts
+ *   - Can be overridden via AO_AUTH_TOKEN environment variable
+ *   - If no token exists and no env var is set, auth is disabled
+ */
+
+import { randomBytes } from "node:crypto";
+import { readFileSync, writeFileSync, mkdirSync, existsSync } from "node:fs";
+import { join } from "node:path";
+import { homedir } from "node:os";
+
+/** Auth token filename */
+const AUTH_TOKEN_FILENAME = ".ao-auth-token";
+
+/** Lazy-evaluated default data directory (avoids calling homedir() at import time) */
+function getDefaultDataDir(): string {
+  return join(homedir(), ".agent-orchestrator");
+}
+
+/** Get the path to the auth token file */
+export function getAuthTokenPath(dataDir?: string): string {
+  return join(dataDir ?? getDefaultDataDir(), AUTH_TOKEN_FILENAME);
+}
+
+/**
+ * Read the auth token from the environment or token file.
+ * Returns null if no token is configured (auth disabled).
+ *
+ * Priority:
+ *   1. AO_AUTH_TOKEN environment variable
+ *   2. Token file at <dataDir>/.ao-auth-token
+ *   3. null (auth disabled)
+ */
+export function readAuthToken(dataDir?: string): string | null {
+  // 1. Environment variable takes precedence
+  const envToken = process.env["AO_AUTH_TOKEN"];
+  if (envToken && envToken.trim().length > 0) {
+    return envToken.trim();
+  }
+
+  // 2. Read from file
+  const tokenPath = getAuthTokenPath(dataDir);
+  if (existsSync(tokenPath)) {
+    try {
+      const token = readFileSync(tokenPath, "utf-8").trim();
+      if (token.length > 0) {
+        return token;
+      }
+    } catch {
+      // File exists but is unreadable — treat as no token
+    }
+  }
+
+  return null;
+}
+
+/**
+ * Ensure an auth token exists. Reads existing token or generates a new one.
+ * Returns the token string.
+ *
+ * @param dataDir - Data directory (defaults to ~/.agent-orchestrator)
+ */
+export function ensureAuthToken(dataDir?: string): string {
+  // Check env var first
+  const envToken = process.env["AO_AUTH_TOKEN"];
+  if (envToken && envToken.trim().length > 0) {
+    return envToken.trim();
+  }
+
+  const dir = dataDir ?? getDefaultDataDir();
+  const tokenPath = getAuthTokenPath(dir);
+
+  // Try to read existing token
+  if (existsSync(tokenPath)) {
+    try {
+      const token = readFileSync(tokenPath, "utf-8").trim();
+      if (token.length > 0) {
+        return token;
+      }
+    } catch {
+      // Unreadable — regenerate
+    }
+  }
+
+  // Generate new token
+  const token = randomBytes(32).toString("hex");
+
+  // Ensure data directory exists
+  if (!existsSync(dir)) {
+    mkdirSync(dir, { recursive: true });
+  }
+
+  // Write with restrictive permissions (owner-only read/write)
+  writeFileSync(tokenPath, token + "\n", { mode: 0o600 });
+
+  return token;
+}

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -87,6 +87,9 @@ export {
   validateAndStoreOrigin,
 } from "./paths.js";
 
+// Auth — token generation and validation
+export { ensureAuthToken, readAuthToken, getAuthTokenPath } from "./auth.js";
+
 // Config generator — auto-generate config from repo URL
 export {
   isRepoUrl,

--- a/packages/web/server/__tests__/direct-terminal-ws.integration.test.ts
+++ b/packages/web/server/__tests__/direct-terminal-ws.integration.test.ts
@@ -106,8 +106,8 @@ beforeAll(() => {
   execFileSync(TMUX, ["new-session", "-d", "-s", TEST_SESSION, "-x", "80", "-y", "24"], { timeout: 5000 });
   execFileSync(TMUX, ["new-session", "-d", "-s", TEST_HASH_SESSION, "-x", "80", "-y", "24"], { timeout: 5000 });
 
-  // Start the server on a random port
-  terminal = createDirectTerminalServer(TMUX);
+  // Start the server on a random port (auth disabled for tests)
+  terminal = createDirectTerminalServer(TMUX, null);
   terminal.server.listen(0);
   const addr = terminal.server.address();
   port = typeof addr === "object" && addr ? addr.port : 0;

--- a/packages/web/server/direct-terminal-ws.ts
+++ b/packages/web/server/direct-terminal-ws.ts
@@ -7,13 +7,14 @@
  * that tmux requires for clipboard support.
  */
 
-import { createServer, type Server } from "node:http";
+import { createServer, type Server, type IncomingMessage } from "node:http";
 import { spawn } from "node:child_process";
 import { WebSocketServer, WebSocket } from "ws";
 import { spawn as ptySpawn, type IPty } from "node-pty";
 import { homedir, userInfo } from "node:os";
 import { findTmux, resolveTmuxSession, validateSessionId } from "./tmux-utils.js";
 import { isAllowedWebSocketOrigin } from "./origin-validation.js";
+import { readAuthToken } from "@composio/ao-core";
 
 interface TerminalSession {
   sessionId: string;
@@ -32,11 +33,53 @@ export interface DirectTerminalServer {
  * Create the direct terminal WebSocket server.
  * Separated from listen() so tests can control lifecycle.
  */
-export function createDirectTerminalServer(tmuxPath?: string): DirectTerminalServer {
+/**
+ * Check if a raw HTTP request is authenticated.
+ * Checks Authorization header and token query parameter.
+ */
+function isAuthenticated(req: IncomingMessage, authToken: string | null): boolean {
+  if (!authToken) return true; // No token configured — auth disabled
+
+  // Check Authorization: Bearer <token> header
+  const authHeader = req.headers.authorization;
+  if (authHeader) {
+    const parts = authHeader.split(" ");
+    if (parts.length === 2 && parts[0].toLowerCase() === "bearer" && parts[1] === authToken) {
+      return true;
+    }
+  }
+
+  // Check token query parameter
+  const url = new URL(req.url ?? "/", "http://localhost");
+  const queryToken = url.searchParams.get("token");
+  if (queryToken === authToken) {
+    return true;
+  }
+
+  return false;
+}
+
+/**
+ * @param tmuxPath - Path to tmux binary
+ * @param authTokenOverride - Auth token override. Pass `null` to disable auth.
+ *   If undefined, reads from environment/file via readAuthToken().
+ */
+export function createDirectTerminalServer(
+  tmuxPath?: string,
+  authTokenOverride?: string | null,
+): DirectTerminalServer {
   const TMUX = tmuxPath ?? findTmux();
   const activeSessions = new Map<string, TerminalSession>();
+  const authToken = authTokenOverride !== undefined ? authTokenOverride : readAuthToken();
 
   const server = createServer((req, res) => {
+    // Authenticate all HTTP requests
+    if (!isAuthenticated(req, authToken)) {
+      res.writeHead(401, { "Content-Type": "application/json" });
+      res.end(JSON.stringify({ error: "Unauthorized" }));
+      return;
+    }
+
     if (req.url === "/health") {
       res.writeHead(200, { "Content-Type": "application/json" });
       res.end(
@@ -60,6 +103,10 @@ export function createDirectTerminalServer(tmuxPath?: string): DirectTerminalSer
       if (!isAllowedWebSocketOrigin(origin)) {
         console.error("[DirectTerminal] Rejected WebSocket from disallowed origin:", origin);
         callback(false, 403, "Forbidden: origin not allowed");
+        return;
+      }
+      if (!isAuthenticated(info.req, authToken)) {
+        callback(false, 401, "Unauthorized");
         return;
       }
       callback(true);

--- a/packages/web/server/terminal-websocket.ts
+++ b/packages/web/server/terminal-websocket.ts
@@ -7,16 +7,41 @@
  * ttyd handles all the hard parts: xterm.js, WebSocket, ANSI rendering,
  * cursor positioning, resize, input — battle-tested and correct.
  *
- * TODO: Add authentication middleware to verify:
- *   - User is authenticated
- *   - User owns the requested session
- *   - Rate limiting for terminal access
+ * Authentication: Requires AO_AUTH_TOKEN via Authorization header or
+ * token query parameter. Auth is disabled when no token is configured.
  */
 
 import { spawn, type ChildProcess } from "node:child_process";
-import { createServer, request } from "node:http";
+import { createServer, type IncomingMessage, request } from "node:http";
 import { findTmux, resolveTmuxSession, validateSessionId } from "./tmux-utils.js";
 import { isAllowedOrigin } from "./origin-validation.js";
+import { readAuthToken } from "@composio/ao-core";
+
+/** Read auth token once at startup */
+const AUTH_TOKEN = readAuthToken();
+
+/** Check if an HTTP request is authenticated */
+function isAuthenticated(req: IncomingMessage): boolean {
+  if (!AUTH_TOKEN) return true; // No token configured — auth disabled
+
+  // Check Authorization: Bearer <token> header
+  const authHeader = req.headers.authorization;
+  if (authHeader) {
+    const parts = authHeader.split(" ");
+    if (parts.length === 2 && parts[0].toLowerCase() === "bearer" && parts[1] === AUTH_TOKEN) {
+      return true;
+    }
+  }
+
+  // Check token query parameter
+  const url = new URL(req.url ?? "/", "http://localhost");
+  const queryToken = url.searchParams.get("token");
+  if (queryToken === AUTH_TOKEN) {
+    return true;
+  }
+
+  return false;
+}
 
 /** Cached full path to tmux binary */
 const TMUX = findTmux();
@@ -210,6 +235,13 @@ function getOrSpawnTtyd(sessionId: string, tmuxSessionName: string): TtydInstanc
 
 // Simple HTTP API for the dashboard to request terminal URLs
 const server = createServer(async (req, res) => {
+  // Authenticate all requests
+  if (!isAuthenticated(req)) {
+    res.writeHead(401, { "Content-Type": "application/json" });
+    res.end(JSON.stringify({ error: "Unauthorized" }));
+    return;
+  }
+
   const url = new URL(req.url ?? "/", "http://localhost");
 
   // CORS — validate Origin against allowlist (localhost by default, configurable via AO_ALLOWED_ORIGINS)

--- a/packages/web/src/app/dev/terminal-test/page.tsx
+++ b/packages/web/src/app/dev/terminal-test/page.tsx
@@ -30,7 +30,10 @@ function TerminalTestPageContent() {
 
   // Fetch available sessions on mount (only active ones)
   useEffect(() => {
-    fetch("/api/sessions?active=true")
+    const authToken = process.env.NEXT_PUBLIC_AO_AUTH_TOKEN;
+    const fetchHeaders: Record<string, string> = {};
+    if (authToken) fetchHeaders["Authorization"] = `Bearer ${authToken}`;
+    fetch("/api/sessions?active=true", { headers: fetchHeaders })
       .then((res) => res.json())
       .then((data) => {
         if (data.sessions && Array.isArray(data.sessions)) {

--- a/packages/web/src/app/sessions/[id]/page.tsx
+++ b/packages/web/src/app/sessions/[id]/page.tsx
@@ -59,13 +59,11 @@ export default function SessionPage() {
     }
   }, [session, id]);
 
-  // Build auth headers for API requests
-  const authToken = process.env.NEXT_PUBLIC_AO_AUTH_TOKEN;
-  const headers: Record<string, string> = {};
-  if (authToken) headers["Authorization"] = `Bearer ${authToken}`;
-
   // Fetch session data (memoized to avoid recreating on every render)
   const fetchSession = useCallback(async () => {
+    const authToken = process.env.NEXT_PUBLIC_AO_AUTH_TOKEN;
+    const headers: Record<string, string> = {};
+    if (authToken) headers["Authorization"] = `Bearer ${authToken}`;
     try {
       const res = await fetch(`/api/sessions/${encodeURIComponent(id)}`, { headers });
       if (res.status === 404) {
@@ -87,6 +85,9 @@ export default function SessionPage() {
 
   const fetchZoneCounts = useCallback(async () => {
     if (!isOrchestrator) return;
+    const authToken = process.env.NEXT_PUBLIC_AO_AUTH_TOKEN;
+    const headers: Record<string, string> = {};
+    if (authToken) headers["Authorization"] = `Bearer ${authToken}`;
     try {
       const res = await fetch("/api/sessions", { headers });
       if (!res.ok) return;

--- a/packages/web/src/app/sessions/[id]/page.tsx
+++ b/packages/web/src/app/sessions/[id]/page.tsx
@@ -59,10 +59,15 @@ export default function SessionPage() {
     }
   }, [session, id]);
 
+  // Build auth headers for API requests
+  const authToken = process.env.NEXT_PUBLIC_AO_AUTH_TOKEN;
+  const headers: Record<string, string> = {};
+  if (authToken) headers["Authorization"] = `Bearer ${authToken}`;
+
   // Fetch session data (memoized to avoid recreating on every render)
   const fetchSession = useCallback(async () => {
     try {
-      const res = await fetch(`/api/sessions/${encodeURIComponent(id)}`);
+      const res = await fetch(`/api/sessions/${encodeURIComponent(id)}`, { headers });
       if (res.status === 404) {
         setError("Session not found");
         setLoading(false);
@@ -83,7 +88,7 @@ export default function SessionPage() {
   const fetchZoneCounts = useCallback(async () => {
     if (!isOrchestrator) return;
     try {
-      const res = await fetch("/api/sessions");
+      const res = await fetch("/api/sessions", { headers });
       if (!res.ok) return;
       const body = (await res.json()) as { sessions: DashboardSession[] };
       const sessions = body.sessions ?? [];

--- a/packages/web/src/components/Dashboard.tsx
+++ b/packages/web/src/components/Dashboard.tsx
@@ -15,6 +15,16 @@ import { PRTableRow } from "./PRStatus";
 import { DynamicFavicon } from "./DynamicFavicon";
 import { useSessionEvents } from "@/hooks/useSessionEvents";
 
+/** Build headers with auth token for API requests */
+function authHeaders(extra?: Record<string, string>): Record<string, string> {
+  const headers: Record<string, string> = { ...extra };
+  const token = process.env.NEXT_PUBLIC_AO_AUTH_TOKEN;
+  if (token) {
+    headers["Authorization"] = `Bearer ${token}`;
+  }
+  return headers;
+}
+
 interface DashboardProps {
   initialSessions: DashboardSession[];
   stats: DashboardStats;
@@ -52,7 +62,7 @@ export function Dashboard({ initialSessions, stats, orchestratorId, projectName 
   const handleSend = async (sessionId: string, message: string) => {
     const res = await fetch(`/api/sessions/${encodeURIComponent(sessionId)}/send`, {
       method: "POST",
-      headers: { "Content-Type": "application/json" },
+      headers: authHeaders({ "Content-Type": "application/json" }),
       body: JSON.stringify({ message }),
     });
     if (!res.ok) {
@@ -64,6 +74,7 @@ export function Dashboard({ initialSessions, stats, orchestratorId, projectName 
     if (!confirm(`Kill session ${sessionId}?`)) return;
     const res = await fetch(`/api/sessions/${encodeURIComponent(sessionId)}/kill`, {
       method: "POST",
+      headers: authHeaders(),
     });
     if (!res.ok) {
       console.error(`Failed to kill ${sessionId}:`, await res.text());
@@ -71,7 +82,10 @@ export function Dashboard({ initialSessions, stats, orchestratorId, projectName 
   };
 
   const handleMerge = async (prNumber: number) => {
-    const res = await fetch(`/api/prs/${prNumber}/merge`, { method: "POST" });
+    const res = await fetch(`/api/prs/${prNumber}/merge`, {
+      method: "POST",
+      headers: authHeaders(),
+    });
     if (!res.ok) {
       console.error(`Failed to merge PR #${prNumber}:`, await res.text());
     }
@@ -81,6 +95,7 @@ export function Dashboard({ initialSessions, stats, orchestratorId, projectName 
     if (!confirm(`Restore session ${sessionId}?`)) return;
     const res = await fetch(`/api/sessions/${encodeURIComponent(sessionId)}/restore`, {
       method: "POST",
+      headers: authHeaders(),
     });
     if (!res.ok) {
       console.error(`Failed to restore ${sessionId}:`, await res.text());

--- a/packages/web/src/components/DirectTerminal.tsx
+++ b/packages/web/src/components/DirectTerminal.tsx
@@ -187,7 +187,9 @@ export function DirectTerminal({
         const protocol = window.location.protocol === "https:" ? "wss:" : "ws:";
         const hostname = window.location.hostname;
         const port = process.env.NEXT_PUBLIC_DIRECT_TERMINAL_PORT ?? "14801";
-        const wsUrl = `${protocol}//${hostname}:${port}/ws?session=${encodeURIComponent(sessionId)}`;
+        const authToken = process.env.NEXT_PUBLIC_AO_AUTH_TOKEN ?? "";
+        const tokenParam = authToken ? `&token=${encodeURIComponent(authToken)}` : "";
+        const wsUrl = `${protocol}//${hostname}:${port}/ws?session=${encodeURIComponent(sessionId)}${tokenParam}`;
 
         // ── Preserve selection while terminal receives output ────────
         // xterm.js clears the selection on every terminal.write(). We

--- a/packages/web/src/components/SessionDetail.tsx
+++ b/packages/web/src/components/SessionDetail.tsx
@@ -88,9 +88,12 @@ async function askAgentToFix(
   try {
     const { title, description } = cleanBugbotComment(comment.body);
     const message = `Please address this review comment:\n\nFile: ${comment.path}\nComment: ${title}\nDescription: ${description}\n\nComment URL: ${comment.url}\n\nAfter fixing, mark the comment as resolved at ${comment.url}`;
+    const headers: Record<string, string> = { "Content-Type": "application/json" };
+    const token = process.env.NEXT_PUBLIC_AO_AUTH_TOKEN;
+    if (token) headers["Authorization"] = `Bearer ${token}`;
     const res = await fetch(`/api/sessions/${encodeURIComponent(sessionId)}/message`, {
       method: "POST",
-      headers: { "Content-Type": "application/json" },
+      headers,
       body: JSON.stringify({ message }),
     });
     if (!res.ok) throw new Error(`HTTP ${res.status}`);

--- a/packages/web/src/components/Terminal.tsx
+++ b/packages/web/src/components/Terminal.tsx
@@ -23,7 +23,9 @@ export function Terminal({ sessionId }: TerminalProps) {
     const protocol = window.location.protocol;
     const hostname = window.location.hostname;
     // URL-encode sessionId to prevent special characters from breaking the URL
-    fetch(`${protocol}//${hostname}:${port}/terminal?session=${encodeURIComponent(sessionId)}`)
+    const authToken = process.env.NEXT_PUBLIC_AO_AUTH_TOKEN ?? "";
+    const tokenParam = authToken ? `&token=${encodeURIComponent(authToken)}` : "";
+    fetch(`${protocol}//${hostname}:${port}/terminal?session=${encodeURIComponent(sessionId)}${tokenParam}`)
       .then((res) => {
         if (!res.ok) throw new Error(`HTTP ${res.status}`);
         return res.json() as Promise<{ url: string }>;

--- a/packages/web/src/hooks/useSessionEvents.ts
+++ b/packages/web/src/hooks/useSessionEvents.ts
@@ -41,7 +41,9 @@ export function useSessionEvents(initialSessions: DashboardSession[]): Dashboard
   }, [initialSessions]);
 
   useEffect(() => {
-    const es = new EventSource("/api/events");
+    const authToken = process.env.NEXT_PUBLIC_AO_AUTH_TOKEN ?? "";
+    const tokenParam = authToken ? `?token=${encodeURIComponent(authToken)}` : "";
+    const es = new EventSource(`/api/events${tokenParam}`);
 
     es.onmessage = (event: MessageEvent) => {
       try {

--- a/packages/web/src/lib/__tests__/auth.test.ts
+++ b/packages/web/src/lib/__tests__/auth.test.ts
@@ -1,0 +1,86 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+
+// Mock readAuthToken before importing auth module
+let mockToken: string | null = null;
+
+vi.mock("@composio/ao-core", () => ({
+  readAuthToken: () => mockToken,
+}));
+
+// Import after mocking
+import { validateRawRequest } from "../auth.js";
+
+beforeEach(() => {
+  mockToken = null;
+});
+
+afterEach(() => {
+  mockToken = null;
+});
+
+describe("validateRawRequest", () => {
+  it("returns true when no token configured", () => {
+    const result = validateRawRequest({}, "/health", null);
+    expect(result).toBe(true);
+  });
+
+  it("returns false when token required but not provided", () => {
+    const result = validateRawRequest({}, "/health", "secret-token");
+    expect(result).toBe(false);
+  });
+
+  it("returns true with valid Authorization header", () => {
+    const result = validateRawRequest(
+      { authorization: "Bearer secret-token" },
+      "/health",
+      "secret-token",
+    );
+    expect(result).toBe(true);
+  });
+
+  it("returns false with invalid Authorization header", () => {
+    const result = validateRawRequest(
+      { authorization: "Bearer wrong-token" },
+      "/health",
+      "secret-token",
+    );
+    expect(result).toBe(false);
+  });
+
+  it("returns true with valid token query parameter", () => {
+    const result = validateRawRequest({}, "/health?token=secret-token", "secret-token");
+    expect(result).toBe(true);
+  });
+
+  it("returns false with invalid token query parameter", () => {
+    const result = validateRawRequest({}, "/health?token=wrong", "secret-token");
+    expect(result).toBe(false);
+  });
+
+  it("is case-insensitive for Bearer prefix", () => {
+    const result = validateRawRequest(
+      { authorization: "bearer secret-token" },
+      "/health",
+      "secret-token",
+    );
+    expect(result).toBe(true);
+  });
+
+  it("rejects malformed Authorization header", () => {
+    const result = validateRawRequest(
+      { authorization: "secret-token" },
+      "/health",
+      "secret-token",
+    );
+    expect(result).toBe(false);
+  });
+
+  it("rejects Basic auth scheme", () => {
+    const result = validateRawRequest(
+      { authorization: "Basic secret-token" },
+      "/health",
+      "secret-token",
+    );
+    expect(result).toBe(false);
+  });
+});

--- a/packages/web/src/lib/auth.ts
+++ b/packages/web/src/lib/auth.ts
@@ -1,0 +1,102 @@
+/**
+ * Authentication helpers for the web dashboard.
+ *
+ * Validates incoming requests against the shared auth token.
+ * The token is read from:
+ *   1. AO_AUTH_TOKEN environment variable
+ *   2. ~/.agent-orchestrator/.ao-auth-token file
+ *
+ * If no token is configured, auth is disabled (all requests pass).
+ */
+
+import { NextResponse, type NextRequest } from "next/server";
+import { readAuthToken } from "@composio/ao-core";
+
+/** Cached auth token — read once on first request */
+let cachedToken: string | null | undefined;
+
+/** Get the auth token (cached after first read) */
+export function getAuthToken(): string | null {
+  if (cachedToken === undefined) {
+    cachedToken = readAuthToken();
+  }
+  return cachedToken;
+}
+
+/**
+ * Validate an incoming Next.js request.
+ *
+ * Returns null if the request is authorized (caller should proceed).
+ * Returns a 401 NextResponse if the request is unauthorized.
+ *
+ * Auth is disabled (all requests pass) when no token is configured.
+ */
+export function validateRequest(request: NextRequest): NextResponse | null {
+  const token = getAuthToken();
+
+  // No token configured — auth disabled
+  if (!token) {
+    return null;
+  }
+
+  // Check Authorization: Bearer <token> header
+  const authHeader = request.headers.get("authorization");
+  if (authHeader) {
+    const parts = authHeader.split(" ");
+    if (parts.length === 2 && parts[0].toLowerCase() === "bearer" && parts[1] === token) {
+      return null; // Valid
+    }
+  }
+
+  // Check token query parameter (for EventSource/WebSocket which can't set headers)
+  const url = new URL(request.url);
+  const queryToken = url.searchParams.get("token");
+  if (queryToken === token) {
+    return null; // Valid
+  }
+
+  return NextResponse.json(
+    { error: "Unauthorized: missing or invalid auth token" },
+    { status: 401 },
+  );
+}
+
+/**
+ * Validate a raw HTTP request (for standalone servers outside Next.js).
+ *
+ * Checks Authorization header and token query parameter.
+ * Returns true if the request is authorized, false otherwise.
+ */
+export function validateRawRequest(
+  headers: { authorization?: string; [key: string]: string | string[] | undefined },
+  url: string,
+  token: string | null,
+): boolean {
+  // No token configured — auth disabled
+  if (!token) {
+    return true;
+  }
+
+  // Check Authorization: Bearer <token> header
+  const authHeader =
+    typeof headers.authorization === "string" ? headers.authorization : undefined;
+  if (authHeader) {
+    const parts = authHeader.split(" ");
+    if (parts.length === 2 && parts[0].toLowerCase() === "bearer" && parts[1] === token) {
+      return true;
+    }
+  }
+
+  // Check token query parameter
+  try {
+    const parsed = new URL(url, "http://localhost");
+    const queryToken = parsed.searchParams.get("token");
+    if (queryToken === token) {
+      return true;
+    }
+  } catch {
+    // Invalid URL — deny
+  }
+
+  return false;
+}

--- a/packages/web/src/middleware.ts
+++ b/packages/web/src/middleware.ts
@@ -1,16 +1,25 @@
 /**
- * Next.js middleware for CSRF protection on API routes.
+ * Next.js middleware — authentication and CSRF protection for API routes.
  *
- * For state-changing methods (POST, PUT, DELETE, PATCH) on /api/* routes:
- * - If Origin header is present, validate it against the allowlist
- * - If Origin header is absent, allow (non-browser clients like curl/CLI)
- * - Reject requests with disallowed or "null" Origin
+ * 1. Authentication: Checks Authorization: Bearer <token> header or token
+ *    query parameter against the shared auth token. Returns 401 for
+ *    unauthorized requests. Auth is disabled when no token is configured.
  *
- * GET/HEAD/OPTIONS are always allowed (read-only, no CSRF risk).
+ * 2. CSRF protection: For state-changing methods (POST, PUT, DELETE, PATCH):
+ *    - If Origin header is present, validate it against the allowlist
+ *    - If Origin header is absent, allow (non-browser clients like curl/CLI)
+ *    - Reject requests with disallowed or "null" Origin
+ *
+ * GET/HEAD/OPTIONS are always allowed past CSRF check (read-only, no CSRF risk).
  *
  * NOTE: Origin validation logic is duplicated from server/origin-validation.ts
  * because Next.js middleware runs in the Edge Runtime and cannot import
  * Node.js server modules. Keep both in sync when updating the allowlist.
+ *
+ * NOTE: Reads token from AO_AUTH_TOKEN env var only (not from file).
+ * The `ao start` command sets this env var when launching the dashboard.
+ * This avoids importing node:fs/node:os which are not available in
+ * Next.js Edge Runtime (where middleware runs).
  */
 
 import { NextResponse, type NextRequest } from "next/server";
@@ -55,32 +64,63 @@ function isAllowedOrigin(origin: string | null): boolean {
   return false;
 }
 
+function getToken(): string | null {
+  const token = process.env["AO_AUTH_TOKEN"];
+  return token && token.trim().length > 0 ? token.trim() : null;
+}
+
 const STATE_CHANGING_METHODS = new Set(["POST", "PUT", "DELETE", "PATCH"]);
 
-export function middleware(request: NextRequest) {
-  // Only check state-changing methods
-  if (!STATE_CHANGING_METHODS.has(request.method)) {
-    return NextResponse.next();
+export function middleware(request: NextRequest): NextResponse | undefined {
+  // --- Authentication check ---
+  const token = getToken();
+
+  if (token) {
+    let authenticated = false;
+
+    // Check Authorization: Bearer <token> header
+    const authHeader = request.headers.get("authorization");
+    if (authHeader) {
+      const parts = authHeader.split(" ");
+      if (parts.length === 2 && parts[0].toLowerCase() === "bearer" && parts[1] === token) {
+        authenticated = true;
+      }
+    }
+
+    // Check token query parameter (for EventSource which can't set headers)
+    if (!authenticated) {
+      const url = new URL(request.url);
+      const queryToken = url.searchParams.get("token");
+      if (queryToken === token) {
+        authenticated = true;
+      }
+    }
+
+    if (!authenticated) {
+      return NextResponse.json(
+        { error: "Unauthorized: missing or invalid auth token" },
+        { status: 401 },
+      );
+    }
   }
 
-  const origin = request.headers.get("origin");
+  // --- CSRF protection for state-changing methods ---
+  if (STATE_CHANGING_METHODS.has(request.method)) {
+    const origin = request.headers.get("origin");
 
-  // No Origin header = non-browser client (curl, CLI, server-to-server) — allow
-  if (origin === null) {
-    return NextResponse.next();
-  }
-
-  // Origin header present but disallowed — reject
-  if (!isAllowedOrigin(origin)) {
-    return NextResponse.json(
-      { error: "Forbidden: origin not allowed" },
-      { status: 403 },
-    );
+    // No Origin header = non-browser client (curl, CLI, server-to-server) — allow
+    if (origin !== null && !isAllowedOrigin(origin)) {
+      return NextResponse.json(
+        { error: "Forbidden: origin not allowed" },
+        { status: 403 },
+      );
+    }
   }
 
   return NextResponse.next();
 }
 
+/** Only protect API routes — dashboard pages are read-only */
 export const config = {
   matcher: "/api/:path*",
 };


### PR DESCRIPTION
## Summary

- Generate shared auth token at startup (`~/.agent-orchestrator/.ao-auth-token`)
- Protect all Next.js API routes via middleware (`Authorization: Bearer <token>` or `?token=` query param)
- Protect WebSocket server with `verifyClient` callback
- Protect terminal HTTP server with auth check
- Update all frontend components to send auth token from `NEXT_PUBLIC_AO_AUTH_TOKEN` env var
- `ao start` / `ao dashboard` generate and display the auth token

Closes #1

---

Autonomously developed with the lightbulb skill.

— Claude